### PR TITLE
patch: [DO-2602] Add access file

### DIFF
--- a/.github/access.yaml
+++ b/.github/access.yaml
@@ -1,0 +1,5 @@
+policies:
+- claims:
+    repository: flocksafety/nativeML
+  permissions:
+    contents: write


### PR DESCRIPTION
This PR adds an access file, allowing another repo to read/write commmits to this repo without using a privileged token.